### PR TITLE
Filter mitigation toggles dynamically based on BusinessProfile filtered graph topology

### DIFF
--- a/visualizer/src/main/java/com/initializer/controller/VisualizerController.java
+++ b/visualizer/src/main/java/com/initializer/controller/VisualizerController.java
@@ -106,7 +106,16 @@ public class VisualizerController {
     @GetMapping("/mitigations")
     public ResponseEntity<List<MitigationDTO>> getMitigations() {
 
-        return ResponseEntity.ok(graphService.getMitigations());
+        BusinessProfileEntity profile =
+                businessProfileService.getLatestProfile();
+
+        if (profile == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(
+                graphService.getMitigations(profile)
+        );
     }
 
 

--- a/visualizer/src/main/java/com/initializer/services/GraphService.java
+++ b/visualizer/src/main/java/com/initializer/services/GraphService.java
@@ -175,9 +175,33 @@ private void removeNodeById(
     }
 }
 
-public List<MitigationDTO> getMitigations() {
+public List<MitigationDTO> getMitigations(BusinessProfileEntity profile) {
 
-    return mitigationRepository.findAll()
+    // Build the graph with the current profile filtering applied
+    DirectedWeightedMultigraph<Node, Edge> graph =
+            getFilteredGraph(profile, null);
+
+    // Collect mitigation IDs tied to edges that still exist
+    java.util.Set<Integer> mitigationIds = new java.util.HashSet<>();
+
+    for (EdgeEntity edgeEntity : edgeRepository.findAll()) {
+
+        String sourceId = edgeEntity.getSourceNode().getNodeType();
+        String targetId = edgeEntity.getTargetNode().getNodeType();
+
+        boolean edgeStillExists = graph.edgeSet().stream().anyMatch(edge ->
+                graph.getEdgeSource(edge).getId().equals(sourceId) &&
+                graph.getEdgeTarget(edge).getId().equals(targetId)
+        );
+
+        if (edgeStillExists) {
+
+            edgeEntity.getMitigationEffects().forEach(effect ->
+                    mitigationIds.add(effect.getMitigation().getMitID()));
+        }
+    }
+
+    return mitigationRepository.findAllById(mitigationIds)
             .stream()
             .map(m -> new MitigationDTO(
                     m.getMitID(),


### PR DESCRIPTION
Mitigation controls are now dynamically derived from the filtered graph topology.

When infrastructure components are disabled via BusinessProfile (VPN, Web App, SaaS, File Server, IdP), the corresponding nodes and edges are removed from the graph. The /api/mitigations endpoint now returns only mitigations associated with edges that remain in the filtered graph.

This ensures the mitigation toggle panel accurately reflects the active attack surface of the configured environment.